### PR TITLE
Handle CS connection failures in Discord bot command

### DIFF
--- a/discord/bot.py
+++ b/discord/bot.py
@@ -40,6 +40,7 @@ async def connect_to_cs():
         logging.info("Успешно подключено к CS Server")
     except Exception as e:
         logging.error(f"Ошибка при соединении с CS Server: {e}")
+        raise
 
 # Периодическое задание для обновления статуса
 @tasks.loop(seconds=config.STATUS_INTERVAL)  # Задача будет выполняться каждые 10 секунд

--- a/discord/bot_commands.py
+++ b/discord/bot_commands.py
@@ -41,16 +41,17 @@ async def cmd_clear(interaction: discord.Interaction, amount: int = 0):
 @commands.has_permissions(manage_messages=True)  # Проверка прав пользователя
 async def cmd_connect_to_cs(interaction: discord.Interaction):
     if srv.is_connected:
-		    srv.disconnect()
-  
+        srv.disconnect()
+
     # Вызываем функцию подключения к серверу
     try:
         await connect_to_cs()
-        logging.info(f"Подключился к CS Server")
-        await interaction.response.send_message("Успешно подключено к серверу!", ephemeral=True)
     except Exception as e:
         logging.error(f"Ошибка при подключении к CS Server: {e}")
         await interaction.response.send_message('Ошибка при подключении к CS Server. Проверьте логи.', ephemeral=True)
+    else:
+        logging.info("Подключился к CS Server")
+        await interaction.response.send_message("Успешно подключено к серверу!", ephemeral=True)
 
 #-------------------------------------------------------------------
 #-- Команды для регистрации игроков


### PR DESCRIPTION
## Summary
- re-raise CS connection failures from `connect_to_cs` so callers can detect and react to failed RCON reconnect attempts
- adjust `/connect_to_cs` to rely on the propagated failure, logging and responding with an error instead of a success message when reconnection does not succeed

## Testing
- python - <<'PY'  # stub external deps and invoke cmd_connect_to_cs to simulate an offline server


------
https://chatgpt.com/codex/tasks/task_e_68d5c747c3448327b042ef85b11b3767